### PR TITLE
Fix README badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stars vs Sentiment Portfolio
 
-[![GitHub Pages](https://github.com/username/stars-v-sentiment-portfolio/actions/workflows/pages.yml/badge.svg)](https://github.com/username/stars-v-sentiment-portfolio/actions/workflows/pages.yml)
+[![GitHub Pages](https://github.com/username/stars-v-sentiment-portfolio/actions/workflows/pages.yml/badge.svg)](https://mcnabb998.github.io/Data-Sci-Portfolios/)
 ![Python](https://img.shields.io/badge/python-3.10-blue)
 
 A collection of data-science projects examining how star ratings align with text sentiment, alongside a sample sports analytics study. Each project highlights methods, visuals, and reproducible code using open datasets.


### PR DESCRIPTION
## Summary
- point GitHub Pages badge to https://mcnabb998.github.io/Data-Sci-Portfolios/

## Testing
- `python -m py_compile projects/amazon-stars-vs-sentiment/data/get_data.py projects/amazon-stars-vs-sentiment/notebooks/export_figures.py`
- `make -C projects/amazon-stars-vs-sentiment -n all`

------
https://chatgpt.com/codex/tasks/task_e_68576f226b6083288c9cae12ecb43cef