### PR TITLE
Clarify sample size in hardware docs

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,3 +1,3 @@
 # Hardware Notes
 
-For full-scale processing of the 66M-row dataset we recommend using a GPU-enabled instance with at least 24 GB of VRAM (e.g., NVIDIA RTX 6000 or AWS p3.2xlarge). CPU preprocessing benefits from 32+ GB RAM.
+The provided scripts process a 1M-row sample, but for full-scale processing of the 66M-row dataset we recommend using a GPU-enabled instance with at least 24 GB of VRAM (e.g., NVIDIA RTX 6000 or AWS p3.2xlarge). CPU preprocessing benefits from 32+ GB RAM.


### PR DESCRIPTION
## Summary
- note that the provided scripts handle only a 1M-row sample

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686026660b888328bf5dbdcc5d83f3e5