### PR TITLE
Add CONTRIBUTING guide

### DIFF
--- a/projects/amazon-stars-vs-sentiment/CONTRIBUTING.md
+++ b/projects/amazon-stars-vs-sentiment/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing Guide
+
+Thanks for your interest in improving the **Amazon Stars vs Sentiment** project! We welcome issues and pull requests from the community.
+
+## Getting Started
+
+1. **Fork the repository** and create your branch from `main`.
+2. If you plan a large change, please [open an issue](../../issues) to discuss first.
+3. Create a clean Python 3.10 environment using the provided `environment.yml`.
+4. Run `make all` to verify everything works before submitting.
+
+## Pull Request Checklist
+
+- Keep code lint‑free with `black` and import sorting using `isort`.
+- Include unit tests for new functionality where applicable.
+- Document any new features in the README or notebooks.
+- Ensure that notebooks execute without errors.
+
+## Reporting Bugs
+
+Open an issue with a minimal example demonstrating the problem. Include OS and Python version information.
+
+## License
+
+Contributions are accepted under the MIT License.


### PR DESCRIPTION
## Summary
- add a contributing guide for the Amazon Stars vs Sentiment project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686026954f9c83288529772e1166495a