### PR TITLE
Fix figure export paths

### DIFF
--- a/projects/amazon-stars-vs-sentiment/notebooks/export_figures.py
+++ b/projects/amazon-stars-vs-sentiment/notebooks/export_figures.py
@@ -6,8 +6,7 @@ FIGURES = [
     'star_counts.png',
     'divergence_hist.png',
     'polarity_vs_rating.png',
-    'helpful_vs_div.png',
-    'shap_top20.png'
+    'helpful_vs_divergence.png'
 ]
 
 def main(out_dir):


### PR DESCRIPTION
## Summary
- rename helpful_vs_div.png to helpful_vs_divergence.png
- remove shap_top20.png from export list

## Testing
- `python -m py_compile projects/amazon-stars-vs-sentiment/notebooks/export_figures.py`


------
https://chatgpt.com/codex/tasks/task_e_6860269ecd1c8328acd1833923e75bc5