### PR TITLE
Add tqdm dependency

### DIFF
--- a/projects/amazon-stars-vs-sentiment/environment.yml
+++ b/projects/amazon-stars-vs-sentiment/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - jupyterlab
   - ipywidgets
   - ipykernel
+  - tqdm


### PR DESCRIPTION
## Summary
- include `tqdm` in the `amazon-stars-vs-sentiment` conda environment

## Testing
- `python3 -m py_compile projects/amazon-stars-vs-sentiment/data/get_data.py`


------
https://chatgpt.com/codex/tasks/task_e_686026a47780832886ceabea76e059eb