### PR TITLE
Fix README: remove missing sports mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Pages](https://github.com/username/stars-v-sentiment-portfolio/actions/workflows/pages.yml/badge.svg)](https://mcnabb998.github.io/Data-Sci-Portfolios/)
 ![Python](https://img.shields.io/badge/python-3.10-blue)
 
-A collection of data-science projects examining how star ratings align with text sentiment, alongside a sample sports analytics study. Each project highlights methods, visuals, and reproducible code using open datasets.
+A collection of data-science projects examining how star ratings align with text sentiment. Each project highlights methods, visuals, and reproducible code using open datasets.
 
 The `docs/` folder contains a minimal GitHub Pages site that links out to individual portfolio pieces. Project-specific materials live under `projects/`, each with its own README and assets.
 


### PR DESCRIPTION
## Summary
- update README wording to remove mention of a non-existent sports analytics study

## Testing
- `find projects -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_686026b025c88328882366f2b3b1a61d