### PR TITLE
Fix GitHub Actions artifact deprecation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v2
         with:
           path: docs
-      - uses: actions/deploy-pages@v1
+      - uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- use newer GitHub Actions versions for Pages workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68610b838b8483289ef20b2be6930226