### PR TITLE
Fix GitHub Pages build by updating workflow actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs
-      - uses: actions/deploy-pages@v2
+      - uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- update the Pages workflow to use the latest actions

## Testing
- `No root Makefile tests`

------
https://chatgpt.com/codex/tasks/task_e_68610dd4e0f4832890306ee797f3cbe6