### PR TITLE
Fix GitHub Pages workflow environment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- include required `environment` block in pages workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68610eeec8608328bad903a6f34835bc