### PR TITLE
Fix broken project pages

### DIFF
--- a/docs/projects/airbnb-price-predictor/index.md
+++ b/docs/projects/airbnb-price-predictor/index.md
@@ -1,0 +1,20 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# Airbnb Price Predictor 🏠💵
+
+> **Note:** This project is in progress. It will demonstrate a basic pricing model using open Airbnb listing data.
+
+The aim is to showcase feature selection and regression modeling to estimate nightly rental prices in various cities.
+
+## Project Status
+- Code & notebooks: *in progress*
+- Initial model: *planned*
+
+## Quick Start
+```
+cd projects/airbnb-price-predictor
+conda env create -f environment.yml
+conda activate airbnb-price
+```

--- a/docs/projects/amazon-stars-vs-sentiment/index.md
+++ b/docs/projects/amazon-stars-vs-sentiment/index.md
@@ -1,0 +1,142 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+
+# Amazon “Stars vs Sentiment” 📦⭐️📝
+
+**A complete investigation of how often Amazon star ratings disagree with the
+written sentiment of the reviews that accompany them.**  
+Using one million Clothing • Shoes • Jewelry reviews from the 2023 Amazon
+corpus, we measure *sentiment drift*, visualise its distribution, and show how a
+simple **divergence score** can power trust dashboards, seller alerts, and
+spam-detection pipelines.
+
+> **Headline:** 64 % of reviews are self‑consistent, yet **11 % differ by more
+> than one full star** between text and rating—enough to mislead buyers and
+> skew ranking models.
+
+---
+
+## 🚦 Project Status
+
+| Component | State |
+|-----------|-------|
+| White paper (PDF) | 🚫 not in repository |
+| 10‑slide video (7 min) | 🚫 not in repository |
+| Code & notebooks | ✅ pushed to `main` |
+| MiniLM star‑prediction fine‑tune | 🔄 optional – planned Q4 2025 |
+
+---
+
+## 🔍 Research Questions
+
+1. **Frequency** – How often does textual sentiment disagree with star ratings?  
+2. **Drivers** – Do helpful votes, verified purchases, or brand patterns
+   explain high drift?  
+3. **Prediction** – Can the residual between text sentiment and expected stars
+   signal review manipulation?
+
+---
+
+## 📊 Key Findings
+
+| Insight | Evidence |
+|---------|----------|
+| 64 % of reviews align (divergence ≈ 0) | `results/divergence_hist.png` |
+| **11 %** exceed ± 1 divergence → strong mis‑match | histogram tails |
+| Average drift **+ 0 .04** → mild positivity bias | `notebooks/01_EDA.ipynb` |
+| Verified‑purchase reviews show 40 % lower drift odds | Appendix C Q4 |
+| Divergence + meta features ⇒ precision 0.55 for spam | Appendix C Q7 |
+
+_Divergence = sentiment score − normalised star, where stars 1‑5 map to
+−1…+1._
+
+---
+
+## 🗂️ Repository Layout
+```
+.
+├── data/                         # parquet slices & model artefacts
+│   └── get_data.py              # streaming download + sample
+├── notebooks/
+│   └── 01_EDA.ipynb             # sentiment, divergence, figures
+├── results/
+│   ├── star_counts.png
+│   ├── divergence_hist.png
+│   ├── polarity_vs_rating.png
+│   └── helpful_vs_divergence.png
+├── environment.yml
+└── README.md                    # this file
+```
+---
+
+## ⚙️ Quick Start
+```bash
+git clone https://github.com/<your‑org>/stars-vs-sentiment.git
+cd stars-vs-sentiment
+
+# 1.  Create environment
+conda env create -f environment.yml
+conda activate stars-sentiment
+
+# 2.  End‑to‑end run  (≈ 15 min CPU • 4 min single A10 GPU)
+make all
+```
+`make all` streams a one‑million‑row sample, scores sentiment with DistilBERT,
+computes divergence, and regenerates every figure under `results/`.
+
+---
+
+## 🛠️ Methodology at a Glance
+
+| Stage | Tool / Model |
+|-------|--------------|
+| Ingest | HF datasets → 1 M stratified rows |
+| Clean  | HTML strip • emoji removal • language filter |
+| Sentiment | DistilBERT SST‑2 (binary ± 1) |
+| Divergence | `sentiment − (star−3)/2` |
+| EDA | pandas & seaborn |
+| Spam test | XGBoost on divergence + length + account‑age |
+| Compute | CPU 15 min / A10 GPU 4 min |
+
+---
+
+## 📈 Reproduce Every Figure
+```bash
+jupyter nbconvert --execute --to notebook   --inplace notebooks/01_EDA.ipynb
+```
+All PNGs refresh under `results/`, and the notebook records runtime logs.
+
+---
+
+## 🤖 Run the Modeling Notebook
+The notebook `notebooks/02_Modeling.ipynb` fine-tunes a small BERT regressor.
+It expects `data/clean_1M.parquet`, which is produced during the EDA step.
+Run `make eda` or execute `notebooks/01_EDA.ipynb` first so the file exists.
+
+---
+
+## 🛡️ Ethical & Fairness Guard‑Rails
+* Reviewer IDs hashed; no PII stored.  
+* Fairness dashboard flags any subgroup with drift > 0 .05.  
+* Divergence badge shown only after 30 reviews to deter gaming.  
+* Human moderation required before penalties.
+
+---
+
+## 🤝 Contributing
+Bug reports and pull requests welcome—see `CONTRIBUTING.md`.
+
+---
+
+## 📜 License
+* Code — MIT License  
+* Review text — Amazon Research License (non‑commercial)
+
+---
+
+## 📚 References
+Hou Y. et al. (2024) *Bridging Language and Items for Retrieval and Recommendation.* arXiv 2403.03952  
+Mukherjee A. et al. (2013) *What Yelp Fake Review Filter Might Be Doing?* WWW Companion  
+Sanh V. et al. (2019) *DistilBERT, a Distilled Version of BERT.* arXiv 1910.01108  

--- a/docs/projects/disease-diagnosis-symptoms/index.md
+++ b/docs/projects/disease-diagnosis-symptoms/index.md
@@ -1,0 +1,20 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# Disease Diagnosis from Symptoms ⚕️🔍
+
+> **Note:** This project is in progress. It will provide a toy example of symptom-based disease prediction using public medical datasets.
+
+The objective is to illustrate feature encoding for categorical symptoms and evaluate simple classification models.
+
+## Project Status
+- Code & notebooks: *in progress*
+- Baseline classifier: *planned*
+
+## Quick Start
+```
+cd projects/disease-diagnosis-symptoms
+conda env create -f environment.yml
+conda activate disease-dx
+```

--- a/docs/projects/fema-flood-claims/index.md
+++ b/docs/projects/fema-flood-claims/index.md
@@ -1,0 +1,122 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# FEMA Flood Insurance Claim Prediction Model 🏚️💧📈
+
+**A small exploration of historical FEMA claims to estimate the likelihood of a property filing a flood insurance claim.**
+This starter project sketches a workflow for feature engineering and model prototyping using open FEMA datasets.
+> **Note:** This project is being updated for the portfolio. Current scripts and notebooks are placeholders until the full pipeline is published.
+
+> **Headline:** Only a fraction of flood‑prone homes ever file a claim, yet location and construction features yield early warning scores.
+
+---
+
+## 🚦 Project Status
+
+| Component | State |
+|-----------|-------|
+| White paper (PDF) | 🚫 not in repository |
+| 10‑slide video (7 min) | 🚫 not in repository |
+| Code & notebooks | 📝 placeholder - updating for portfolio |
+| Baseline claim‑risk model | 🔄 planned Q4 2024 |
+
+---
+
+## 🔍 Research Questions
+
+1. **Risk Factors** – Which property attributes correlate most with claim history?
+2. **Predictability** – Can we predict claim probability from location and dwelling features alone?
+3. **Resilience** – How does recent mitigation investment shift risk scores?
+
+---
+
+## 📊 Key Findings
+
+| Insight | Evidence |
+|---------|----------|
+| Historical claims cluster along repeat‑flood zones | preliminary EDA maps |
+| Older construction correlates with higher claim odds | `notebooks/01_EDA.ipynb` |
+| Mitigation grants reduce predicted risk by ~15% | placeholder analysis |
+
+---
+
+## 🗂️ Repository Layout
+```
+projects/fema-flood-claims/
+├── data/                # raw FEMA NFIP claim exports
+├── notebooks/           # exploration & modeling
+├── results/             # charts and model artefacts
+└── README.md            # this file
+```
+---
+
+## ⚙️ Quick Start
+```bash
+# clone the full portfolio
+git clone https://github.com/<your-org>/Data-Sci-Portfolios.git
+cd Data-Sci-Portfolios/projects/fema-flood-claims
+
+# create environment (example)
+conda env create -f environment.yml
+conda activate fema-claims
+
+# run exploratory notebook
+jupyter nbconvert --execute --to notebook --inplace notebooks/01_EDA.ipynb
+```
+
+## 🚧 Ongoing Updates
+
+This project is in its early portfolio stage. Upcoming improvements will:
+- provide sample data slices under `data/`
+- publish step-by-step notebooks
+- share baseline model metrics
+
+---
+
+## 🛠️ Methodology at a Glance
+
+| Stage | Tool / Model |
+|-------|--------------|
+| Ingest | FEMA NFIP raw CSVs |
+| Clean | pandas ETL scripts |
+| Features | flood zone, elevation, structure age |
+| Model | XGBoost probability of claim |
+| Evaluate | ROC‑AUC and gain curves |
+
+---
+
+## 📈 Reproduce Every Figure
+```bash
+jupyter nbconvert --execute --to notebook --inplace notebooks/01_EDA.ipynb
+```
+Figures update under `results/` and the notebook captures run logs.
+
+---
+
+## 🤖 Run the Modeling Notebook
+`notebooks/02_Modeling.ipynb` trains a simple gradient boosting model.
+Ensure processed parquet files from the EDA step exist before running.
+
+---
+
+## 🛡️ Ethical & Fairness Guard‑Rails
+* Claims data contains no personally identifiable information.
+* Risk scores should be communicated alongside uncertainty ranges.
+* Use only for exploratory purposes unless validated against production data.
+
+---
+
+## 🤝 Contributing
+Pull requests are welcome. For major changes, open an issue first to discuss what you would like to change.
+
+---
+
+## 📜 License
+Code released under the MIT License. FEMA data is public domain.
+
+---
+
+## 📚 References
+FEMA National Flood Insurance Program OpenFEMA Dataset
+Smith J. et al. (2022) *Predicting Flood Claim Frequency with Machine Learning.*

--- a/docs/projects/movie-review-sentiment/index.md
+++ b/docs/projects/movie-review-sentiment/index.md
@@ -1,0 +1,23 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# Movie Review Sentiment Pipeline 🎬📝
+
+> **Note:** This project is in progress. Notebooks are placeholders until the full workflow is released.
+
+This sample project analyzes IMDb movie reviews to build a simple sentiment classifier. It illustrates text preprocessing and model evaluation techniques.
+
+## Project Status
+- Code & notebooks: *in progress*
+- Classifier benchmark: *planned*
+
+## Quick Start
+```
+# navigate
+cd projects/movie-review-sentiment
+
+# setup
+conda env create -f environment.yml
+conda activate movie-sentiment
+```

--- a/docs/projects/nyc-taxi-duration/index.md
+++ b/docs/projects/nyc-taxi-duration/index.md
@@ -1,0 +1,23 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# NYC Taxi Trip Duration Model 🚕⏱️
+
+> **Note:** This project is in progress. Folders and notebooks will be updated for the full portfolio release.
+
+A brief demonstration of predicting taxi trip times using the open NYC TLC dataset. The goal is to showcase feature engineering and baseline modeling for regression tasks.
+
+## Project Status
+- Code & notebooks: *in progress*
+- Baseline model: *planned*
+
+## Quick Start
+```
+# clone portfolio and navigate
+cd projects/nyc-taxi-duration
+
+# sample environment setup
+conda env create -f environment.yml
+conda activate nyc-taxi
+```

--- a/docs/projects/real-estate-covid-wfh/index.md
+++ b/docs/projects/real-estate-covid-wfh/index.md
@@ -1,0 +1,119 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# Real Estate COVID WFH Features 🏠💻
+
+> **Note:** This project is under construction. Current folders are being updated for the portfolio.
+
+**A short portfolio piece exploring how pandemic-driven remote work preferences reshaped real estate listings.** Using open MLS data, we identify work‑from‑home amenities and measure their impact on pricing and demand.
+
+> **Headline:** Home offices and fast internet now command a measurable premium in many markets.
+
+---
+
+## 🚦 Project Status
+
+| Component | State |
+|-----------|-------|
+| White paper (PDF) | 🚫 not in repository |
+| 10‑slide summary (5 min) | 🚫 not in repository |
+| Code & notebooks | 📝 placeholder - updating for portfolio |
+| Baseline pricing model | 🔄 planned Q4 2024 |
+
+---
+
+## 🔍 Research Questions
+1. **WFH Amenities** – How often do listings mention dedicated office space or broadband access?
+2. **Pricing Effects** – Do WFH features correlate with higher list prices or faster sales?
+3. **Regional Shifts** – Are suburban markets seeing larger jumps in WFH‑friendly listings?
+
+---
+
+## 📊 Key Findings
+
+| Insight | Evidence |
+|---------|----------|
+| Listings with "home office" spiked after 2020 | preliminary EDA charts |
+| Suburban homes with office space sell faster | `notebooks/01_EDA.ipynb` |
+| Fiber internet availability adds a price premium | placeholder analysis |
+
+---
+
+## 🗂️ Repository Layout
+```
+projects/real-estate-covid-wfh/
+├── data/                # sample MLS exports
+├── notebooks/           # exploration & modeling
+├── results/             # charts and model artifacts
+└── README.md            # this file
+```
+---
+
+## ⚙️ Quick Start
+```bash
+# clone the portfolio
+git clone https://github.com/<your-org>/Data-Sci-Portfolios.git
+cd Data-Sci-Portfolios/projects/real-estate-covid-wfh
+
+# create environment (example)
+conda env create -f environment.yml
+conda activate real-estate-wfh
+
+# run exploratory notebook
+jupyter nbconvert --execute --to notebook --inplace notebooks/01_EDA.ipynb
+```
+
+## 🚧 Ongoing Updates
+This project is in its early portfolio stage. Upcoming improvements will:
+- provide sample data slices under `data/`
+- publish step-by-step notebooks
+- share a baseline pricing model
+
+---
+
+## 🛠️ Methodology at a Glance
+
+| Stage | Tool / Approach |
+|-------|-----------------|
+| Ingest | public MLS dataset CSVs |
+| Clean | pandas ETL scripts |
+| Features | office count, broadband availability, square footage |
+| Model | random forest price premium model |
+| Evaluate | cross validation MAE |
+
+---
+
+## 📈 Reproduce Every Figure
+```bash
+jupyter nbconvert --execute --to notebook --inplace notebooks/01_EDA.ipynb
+```
+Figures update under `results/` and the notebook captures run logs.
+
+---
+
+## 🤖 Run the Modeling Notebook
+`notebooks/02_Modeling.ipynb` trains a simple pricing model.
+Ensure processed data from the EDA step exists before running.
+
+---
+
+## 🛡️ Ethical & Fairness Guard‑Rails
+* Data contains no personal identifiers.
+* Use price predictions responsibly and include uncertainty ranges.
+
+---
+
+## 🤝 Contributing
+Pull requests are welcome. For major changes, open an issue first to discuss what you would like to change.
+
+---
+
+## 📜 License
+Code released under the MIT License. Listing data is public domain.
+
+---
+
+## 📚 References
+National Association of Realtors MLS Data
+Doe J. et al. (2023) *Remote Work and Housing Trends*.

--- a/docs/projects/stock-price-forecast/index.md
+++ b/docs/projects/stock-price-forecast/index.md
@@ -1,0 +1,20 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# Stock Price Trend Forecasting 📈🗓️
+
+> **Note:** This project is in progress. Scripts will illustrate time series forecasting with historical stock prices.
+
+This sample project will experiment with ARIMA and LSTM models to predict short-term stock trends. It is intended for educational purposes only.
+
+## Project Status
+- Code & notebooks: *in progress*
+- Forecast benchmarks: *planned*
+
+## Quick Start
+```
+cd projects/stock-price-forecast
+conda env create -f environment.yml
+conda activate stock-forecast
+```

--- a/docs/projects/traffic-accident-hotspots/index.md
+++ b/docs/projects/traffic-accident-hotspots/index.md
@@ -1,0 +1,20 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# Traffic Accident Hotspot Detection 🚦📍
+
+> **Note:** This project is in progress. Data pipelines and visualization notebooks are forthcoming.
+
+Using open traffic accident reports, this project will identify high-risk locations and visualize hotspot clusters across a city.
+
+## Project Status
+- Code & notebooks: *in progress*
+- Hotspot maps: *planned*
+
+## Quick Start
+```
+cd projects/traffic-accident-hotspots
+conda env create -f environment.yml
+conda activate traffic-hotspots
+```

--- a/docs/projects/weather-data-viz/index.md
+++ b/docs/projects/weather-data-viz/index.md
@@ -1,0 +1,20 @@
+<link rel="stylesheet" href="../../assets/css/style.css">
+[Back to Portfolio](../../index.html)
+
+
+# Meteorological Data Visualization ☁️📊
+
+> **Note:** This project is in progress. Example charts and scripts will be added soon.
+
+This sample shows how to process and plot public weather data to uncover seasonal patterns and anomalies.
+
+## Project Status
+- Code & notebooks: *in progress*
+- Visualization gallery: *planned*
+
+## Quick Start
+```
+cd projects/weather-data-viz
+conda env create -f environment.yml
+conda activate weather-viz
+```


### PR DESCRIPTION
## Summary
- move project pages into the `docs` folder
- expose each README as a Markdown page with styling and a back link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687af95d38bc8328bf71021e849f2565